### PR TITLE
#163550495 citizen user can view all political parties 

### DIFF
--- a/app/api/models/party_model.py
+++ b/app/api/models/party_model.py
@@ -53,3 +53,7 @@ class PartyModel:
 
         self.parties.append(new_party)
         return new_party
+    
+    def return_parties(self):
+        """Return all parties in the list"""
+        return self.parties

--- a/app/api/views/party_views.py
+++ b/app/api/views/party_views.py
@@ -67,3 +67,15 @@ def create_political_party():
                                       "data": [{
                                           "message": "some required fields missing"}]})), 400
 
+###Get all parties
+@parties_route.route('/', methods=['GET']) 
+def return_political_parties():
+    """"This route enables citizen user
+      - to view all political parties"""
+    response = party.return_parties()
+
+    return make_response(jsonify({"status": 200,
+                                  "data": response
+                                  })), 200
+
+

--- a/app/test/basetest.py
+++ b/app/test/basetest.py
@@ -59,7 +59,13 @@ class BaseTest(unittest.TestCase):
             "/api/v1/parties/10000", content_type="application/json"
         )
         return response
-    
+
+    def valid_get_request(self):
+        response = self.client.get(
+            "/api/v1/parties/", content_type="application/json"
+        )
+        return response
+        
     def valid_patch_request(self):
         response = self.client.patch('/api/v1/parties/1/name', data=json.dumps(self.edit_party),
                                         content_type="application/json")

--- a/app/test/test_party.py
+++ b/app/test/test_party.py
@@ -19,6 +19,13 @@ class TestDeleteRequest(BaseTest):
         self.assertEqual(result["status"], 200)
         self.assertEqual(result["data"][0]["message"], "delete successful")
 
+class TestGetRequest(BaseTest):    
+    def test_invalid_delete_request(self):
+        response = self.valid_get_request()
+        result = json.loads(response.data.decode('utf-8'))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(result["status"], 200)
+
 
 class TestPatchRequest(BaseTest):    
     def test_invalid_delete_request(self):


### PR DESCRIPTION
### What does this PR do?

citizen user should be able to create view all political parties.

### Description of Task to be completed?

Created an endpoint  where Citizen user should be able to view all political parties.

### How should this be manually tested?
* Clone the repo by git clone by : https://github.com/lenileiro/politico-api.git

* Navigate into the project by: cd political-api

* activate a virtual environment:
       ```bash
           #!/bin/bash
          $ source venv/bin/activate
      ```

* Install dependencies by: pip install -r requirements.txt
* Run the server by: python run.py
* Hit the following endpoint with postman: http://127.0.0.1:5000/api/v1/parties/ ['GET']

### What are the relevant pivotal tracker stories?
[#163550495](hhttps://www.pivotaltracker.com/story/show/163550495)
screenshot
![image](https://user-images.githubusercontent.com/23293150/52472229-d41f5e80-2ba3-11e9-992d-14f321492e73.png)

