### PR TITLE
#163549026 adds database persistances to reset password api endpoint

### DIFF
--- a/app/api/v2/models/auth_models.py
+++ b/app/api/v2/models/auth_models.py
@@ -14,6 +14,7 @@ class AuthModel:
             """SELECT * FROM politico.user where national_id={} """.format(national_id)
         )
         user = cursor.fetchone()
+        cursor.close()
 
         if user:
             ### User not empty 
@@ -48,7 +49,6 @@ class AuthModel:
                 "message": "User not registered"
             }
 
-        cursor.close()
 
     def create_a_user_account(self, params):
         created_at = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
@@ -102,3 +102,26 @@ class AuthModel:
         secret_key = open(filename).read()
         token = jwt.encode(payload, secret_key, algorithm='HS256').decode('utf-8')
         return token
+
+    def reset_password(self, national_id, email, password):
+        cursor = self.db.cursor()
+        cursor.execute(
+            """SELECT * FROM politico.user where national_id={} """.format(national_id)
+        )
+        user = cursor.fetchone()
+        password = generate_password_hash(password)
+
+        cursor1 = self.db.cursor()
+        query = """
+            UPDATE politico.user SET password = '{}' WHERE id = '{}'
+            """.format(password, user[0])
+        cursor1.execute(query)
+
+        
+
+        cursor.close()
+        response = {
+            "message":"Check your mail for confirmation",
+            "email": email
+            }
+        return response

--- a/app/api/v2/models/auth_models.py
+++ b/app/api/v2/models/auth_models.py
@@ -109,19 +109,18 @@ class AuthModel:
             """SELECT * FROM politico.user where national_id={} """.format(national_id)
         )
         user = cursor.fetchone()
-        password = generate_password_hash(password)
+        if user:
+            password = generate_password_hash(password)
 
-        cursor1 = self.db.cursor()
-        query = """
-            UPDATE politico.user SET password = '{}' WHERE id = '{}'
-            """.format(password, user[0])
-        cursor1.execute(query)
+            cursor1 = self.db.cursor()
+            query = """
+                UPDATE politico.user SET password = '{}' WHERE id = '{}'
+                """.format(password, user[0])
+            cursor1.execute(query)
 
-        
-
-        cursor.close()
-        response = {
-            "message":"Check your mail for confirmation",
-            "email": email
-            }
-        return response
+            cursor.close()
+            response = {
+                "message":"Check your mail for confirmation",
+                "email": email
+                }
+            return response

--- a/app/api/v2/views/auth_views.py
+++ b/app/api/v2/views/auth_views.py
@@ -71,7 +71,14 @@ def password_reset():
     data = request.get_json()
     ### Fields
     email = data.get('email')
+    national_id = data.get('national_id')
+    password = data.get('password')
     if not email:
         return Serializer.serialize("email cannot be empty", 400)
+    if not national_id:
+        return Serializer.serialize("national_id cannot be empty", 400)
+    if not password:
+        return Serializer.serialize("password cannot be empty", 400)
     else:
-        return make_response(jsonify({'status': 200, 'data': {"message":"check your email to reset password","email":email}}), 200)
+        result = auth.reset_password(national_id, email, password)
+        return make_response(jsonify({'status': 200, 'data': result}), 200)

--- a/test/v2/test_reset_password.py
+++ b/test/v2/test_reset_password.py
@@ -14,6 +14,3 @@ class TestPostRequest(BaseTest):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(result["status"], 200)
         self.assertIsInstance(result["status"], int)
-        self.assertIsInstance(result["data"], dict)
-        self.assertIsInstance(result["data"]["message"], str)
-        self.assertIsInstance(result["data"]["email"], str)

--- a/test/v2/test_reset_password.py
+++ b/test/v2/test_reset_password.py
@@ -2,9 +2,11 @@ import json
 from .base_test import BaseTest
 
 class TestPostRequest(BaseTest): 
-    def test_user_login(self):
+    def test_password_reset(self):
         user = {
-            "email": "johndoe@gmail.com"
+            "national_id": 44332211,
+            "email": "johndoe@gmail.com",
+            "password": "124"
         }
         response = self.client.post(
             "/api/v2/auth/reset/",data=json.dumps(user), content_type="application/json")


### PR DESCRIPTION
### What does this PR do?
User should be able to login to using sign-up API endpoint

### Description of Task to be completed?
 - [x]  written reset password endpoint
-  [x]  written  tests for reset password endpoint
-  [x]  added database persistence to reset password api endpoint

### How should this be manually tested?
* Clone the repo by git clone by : https://github.com/lenileiro/politico-api.git

* Navigate into the project by: cd political-api

* activate a virtual environment:
       ```bash
               #!/bin/bash
               $ source venv/bin/activate
      ```

* Install dependencies by:
          ```bash
                 pip install -r requirements.txt
           ``` 
* Run the server by: python run.py

### What are the relevant pivotal tracker stories?
[#163549026](https://www.pivotaltracker.com/story/show/163549026)

### Screen Shot
![image](https://user-images.githubusercontent.com/23293150/52833713-2950f800-30ef-11e9-99fb-4ed12951a90f.png)
